### PR TITLE
Fix typo in readme for wildcard example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo iptables -A OUTPUT -p tcp --dport 443 -m tls --tls-host "www.facebook.com" 
 You can also match subdomains using wildcards like this.
 
 ```bash
-sudo iptables -A OUTPUT -p tcp --dport 443 -m tls --tls-host "\*.googlevideo.com" -j DROP
+sudo iptables -A OUTPUT -p tcp --dport 443 -m tls --tls-host "*.googlevideo.com" -j DROP
 ```
 Another way to specify the hostname matching patterns is to use the hostsets. This is a way to do when you have to match each packet  with a lot of potentially suitable hostnames. While you may write a separate iptables rule for each hostname, it would be very inefficient. A better way is place all the hostnames to the single collection named "hostset". The hostsets are similar to the [ipsets](http://ipset.netfilter.org/) with the difference that they contain host names rather than ip-addresses. The entire hostset can be matches with a single iptables rule:
 


### PR DESCRIPTION
Escaping * in the wildcard example is unnecessary as the domain is quoted.

It should be --tls-host "*.googlevideo.com" or --tls-host \*.googlevideo.com