### PR TITLE
ipt: correct xtables module initialization, fixes #64

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -4,7 +4,7 @@ CLEAN="make clean KERNELDIR=/lib/modules/${kernelver}/build KERNEL_VERSION=$kern
 BUILT_MODULE_NAME=xt_tls
 BUILT_MODULE_LOCATION=src/
 PACKAGE_NAME=xt_tls
-PACKAGE_VERSION=0.3.4
+PACKAGE_VERSION=0.3.5
 #REMAKE_INITRD=yes
 AUTOINSTALL="no"
 POST_INSTALL=dkms/post-install.sh

--- a/ipt/libxt_tls.c
+++ b/ipt/libxt_tls.c
@@ -125,7 +125,7 @@ static struct xtables_match tls_match = {
 	.x6_options	= tls_opts,
 };
 
-void _init(void)
+static __attribute__((constructor)) void xt_tls_mt_ldr(void)
 {
 	xtables_register_match(&tls_match);
 }

--- a/src/xt_tls_main.c
+++ b/src/xt_tls_main.c
@@ -450,5 +450,5 @@ module_exit(tls_mt_exit);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Nils Andreas Svee <nils@stokkdalen.no>");
 MODULE_DESCRIPTION("Xtables: TLS (SNI) matching");
-MODULE_VERSION("0.3.4");
+MODULE_VERSION("0.3.5");
 MODULE_ALIAS("ipt_tls");


### PR DESCRIPTION
Attempt to fix build error on Ubuntu 24.04 (and likely other recent distros)

Compiles and works normally on my install now. Anyone on older systems, please verify it still works there also before I merge this